### PR TITLE
Made Raspberry Pi detection more robust

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ VERSION			:=	$(shell echo $(shell grep -r VERSION= propelleride.pri \
 					| sed -e 's/ /./g')
 
 # if CPU (uname -m) equals...
-ifneq ($(shell cat /etc/os-release | grep "ID=raspbian"),"") # if Raspberry Pi
+ifeq ($(shell cat /etc/os-release | grep "ID=raspbian"),"ID=raspbian") # if Raspberry Pi
 	CPU := armhf
 else
 	ifeq ($(shell uname -m),i686)			# if i686


### PR DESCRIPTION
Previous method returned hostname, which could easily be different from "raspberrypi" if changed by the user, suggested change relies on looking in /etc/os-release for ID=raspbian which is hostname agnostic.

This change has been tested on Raspbian and OSX Yosemite.
