### PR TITLE
Fixed string quoting error in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ VERSION			:=	$(shell echo $(shell grep -r VERSION= propelleride.pri \
 					| sed -e 's/ /./g')
 
 # if CPU (uname -m) equals...
-ifeq ($(shell cat /etc/os-release | grep "ID=raspbian"),"ID=raspbian") # if Raspberry Pi
+ifeq ($(shell cat /etc/os-release | grep "ID=raspbian"),ID=raspbian) # if Raspberry Pi
 	CPU := armhf
 else
 	ifeq ($(shell uname -m),i686)			# if i686


### PR DESCRIPTION
I conflated bash and makefile syntax, which lead to the ifeq comparison failing. This does the trick, and correctly compiles to armhf on a Pi with a user-modified hostname.
