### PR TITLE
Qt str.append modifies the original string

### DIFF
--- a/src/propelleride/compilers/externalcompiler.cpp
+++ b/src/propelleride/compilers/externalcompiler.cpp
@@ -75,9 +75,11 @@ QString ExternalCompiler::build(QString filename,
     QString basefile = infile;
     basefile.chop(pattern_in.size());
 
-    QString outfile = basefile.append(pattern_out);
-    QString retfile = basefile.append(pattern_ret);
+    QString outfile = basefile;
+    QString retfile = basefile;
 
+    outfile += pattern_out;
+    retfile += pattern_ret;
 
     QString exepath = getExecutablePath();
 


### PR DESCRIPTION
This caused extensions to be added twice in some cases. Instead of "outfile = basefile.append(pattern_out)" (which modifies the original basefile), use "outfile = basefile; outfile += pattern_out".