### PR TITLE
added support for fastspin compiler alongside openspin and bstc

### DIFF
--- a/src/propelleride/config/compiler.fastspin
+++ b/src/propelleride/config/compiler.fastspin
@@ -1,0 +1,10 @@
+[General]
+LANGUAGE=spin
+PATTERN_IN=.spin
+PATTERN_OUT=.binary
+PATTERN_RET=.binary
+ARG_FLAGS=
+ARG_LIBRARY=-L%
+ARG_OUTPUT=-o%
+RE_ERROR="(.*?)\\.spin\\s*\\(\\s*([0-9]+)\\s*:\\s*([0-9]+)\\s*\\)\\s*:\\s*error\\s*:\\s*(.*)"
+RE_SUCCESS=(Done)

--- a/src/propelleride/config/config.qrc
+++ b/src/propelleride/config/config.qrc
@@ -2,6 +2,7 @@
 <qresource prefix="/config">
     <file>compiler.bstc</file>
     <file>compiler.openspin</file>
+    <file>compiler.fastspin</file>
     <file>compiler.propbasic</file>
 </qresource>
 </RCC>

--- a/src/propelleride/languages/spin.json
+++ b/src/propelleride/languages/spin.json
@@ -3,7 +3,8 @@
     "extension": [ "spin" ],
     "buildsteps": [
         [ "bstc" ],
-        [ "openspin" ]
+        [ "openspin" ],
+        [ "fastspin" ]
     ],
     "includes": true,
     "syntax": {


### PR DESCRIPTION
Added support for fastspin, which has the same API as openspin but creates LMM PASM code instead of Spin bytecode.
